### PR TITLE
Implement I18N Issues Based on 0.2.8

### DIFF
--- a/includes/conditions/class-wdc-archive_author-condition.php
+++ b/includes/conditions/class-wdc-archive_author-condition.php
@@ -10,7 +10,7 @@ class WDC_Archive_Author_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'archive_author', __( 'Archive Author', 'wdc' ), array
+		parent::__construct( 'archive_author', __( 'Archive Author', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'archive',

--- a/includes/conditions/class-wdc-archive_post_type-condition.php
+++ b/includes/conditions/class-wdc-archive_post_type-condition.php
@@ -10,7 +10,7 @@ class WDC_Archive_Post_Type_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'archive_post_type', __( 'Archive Post Type', 'wdc' ), array
+		parent::__construct( 'archive_post_type', __( 'Archive Post Type', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'archive',

--- a/includes/conditions/class-wdc-archive_taxonomy-condition.php
+++ b/includes/conditions/class-wdc-archive_taxonomy-condition.php
@@ -10,7 +10,7 @@ class WDC_Archive_Taxonomy_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'archive_taxonomy', __( 'Archive Taxonomy', 'wdc' ), array
+		parent::__construct( 'archive_taxonomy', __( 'Archive Taxonomy', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'archive',

--- a/includes/conditions/class-wdc-attachment-condition.php
+++ b/includes/conditions/class-wdc-attachment-condition.php
@@ -10,7 +10,7 @@ class WDC_Attachment_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'attachment', __( 'Attachment', 'wdc' ), array
+		parent::__construct( 'attachment', __( 'Attachment', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'attachment',

--- a/includes/conditions/class-wdc-page-condition.php
+++ b/includes/conditions/class-wdc-page-condition.php
@@ -10,7 +10,7 @@ class WDC_Page_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'page', __( 'Page', 'wdc' ), array
+		parent::__construct( 'page', __( 'Page', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'page',

--- a/includes/conditions/class-wdc-page_parent-condition.php
+++ b/includes/conditions/class-wdc-page_parent-condition.php
@@ -10,7 +10,7 @@ class WDC_Page_Parent_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'page_parent', __( 'Page Parent', 'wdc' ), array
+		parent::__construct( 'page_parent', __( 'Page Parent', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'page',

--- a/includes/conditions/class-wdc-page_template-condition.php
+++ b/includes/conditions/class-wdc-page_template-condition.php
@@ -10,7 +10,7 @@ class WDC_Page_Template_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'page_template', __( 'Page Template', 'wdc' ), array
+		parent::__construct( 'page_template', __( 'Page Template', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'page',
@@ -29,7 +29,7 @@ class WDC_Page_Template_Condition extends WDC_Condition
 	{
 		$post_templates = wdc_get_post_templates();
 
-		$values = array( '' => __( 'Default', 'wdc' ) );
+		$values = array( '' => __( 'Default', 'widget-display-conditions' ) );
 		$values += $post_templates['page'];
 
 		return $values;

--- a/includes/conditions/class-wdc-page_type-condition.php
+++ b/includes/conditions/class-wdc-page_type-condition.php
@@ -10,7 +10,7 @@ class WDC_Page_Type_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'page_type', __( 'Page Type', 'wdc' ), array
+		parent::__construct( 'page_type', __( 'Page Type', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'page',
@@ -29,15 +29,15 @@ class WDC_Page_Type_Condition extends WDC_Condition
 	{
 		return array
 		(
-			'front_page'  => __( 'Front Page', 'wdc' ),
-			'posts_page'  => __( 'Posts Page', 'wdc' ),
-			'search_page' => __( 'Search Page', 'wdc' ),
-			'404_page'    => __( '404 Page (not found)', 'wdc' ),
-			'date_page'   => __( 'Date Page', 'wdc' ),
-			'author_page' => __( 'Author Page', 'wdc' ),
-			'top_level'   => __( 'Top Level Page (no parent)', 'wdc' ),
-			'parent'      => __( 'Parent Page (has children)', 'wdc' ),
-			'child'       => __( 'Child Page (has parent)', 'wdc' ),
+			'front_page'  => __( 'Front Page', 'widget-display-conditions' ),
+			'posts_page'  => __( 'Posts Page', 'widget-display-conditions' ),
+			'search_page' => __( 'Search Page', 'widget-display-conditions' ),
+			'404_page'    => __( '404 Page (not found)', 'widget-display-conditions' ),
+			'date_page'   => __( 'Date Page', 'widget-display-conditions' ),
+			'author_page' => __( 'Author Page', 'widget-display-conditions' ),
+			'top_level'   => __( 'Top Level Page (no parent)', 'widget-display-conditions' ),
+			'parent'      => __( 'Parent Page (has children)', 'widget-display-conditions' ),
+			'child'       => __( 'Child Page (has parent)', 'widget-display-conditions' ),
 		);
 	}
 	

--- a/includes/conditions/class-wdc-post-condition.php
+++ b/includes/conditions/class-wdc-post-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post', __( 'Post', 'wdc' ), array
+		parent::__construct( 'post', __( 'Post', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_category-condition.php
+++ b/includes/conditions/class-wdc-post_category-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Category_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_category', __( 'Post Category', 'wdc' ), array
+		parent::__construct( 'post_category', __( 'Post Category', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_format-condition.php
+++ b/includes/conditions/class-wdc-post_format-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Format_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_format', __( 'Post Format', 'wdc' ), array
+		parent::__construct( 'post_format', __( 'Post Format', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_status-condition.php
+++ b/includes/conditions/class-wdc-post_status-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Status_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_status', __( 'Post Status', 'wdc' ), array
+		parent::__construct( 'post_status', __( 'Post Status', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_tag-condition.php
+++ b/includes/conditions/class-wdc-post_tag-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Tag_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_tag', __( 'Post Tag', 'wdc' ), array
+		parent::__construct( 'post_tag', __( 'Post Tag', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_taxonomy-condition.php
+++ b/includes/conditions/class-wdc-post_taxonomy-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Taxonomy_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_taxonomy', __( 'Post Taxonomy', 'wdc' ), array
+		parent::__construct( 'post_taxonomy', __( 'Post Taxonomy', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-post_template-condition.php
+++ b/includes/conditions/class-wdc-post_template-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Template_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_template', __( 'Post Template', 'wdc' ), array
+		parent::__construct( 'post_template', __( 'Post Template', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',
@@ -31,7 +31,7 @@ class WDC_Post_Template_Condition extends WDC_Condition
 
 		$values = array
 		(
-			'' => __( 'Default', 'wdc' ),
+			'' => __( 'Default', 'widget-display-conditions' ),
 		);
 
 		foreach ( $post_templates as $post_type => $templates ) 

--- a/includes/conditions/class-wdc-post_type-condition.php
+++ b/includes/conditions/class-wdc-post_type-condition.php
@@ -10,7 +10,7 @@ class WDC_Post_Type_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'post_type', __( 'Post Type', 'wdc' ), array
+		parent::__construct( 'post_type', __( 'Post Type', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'post',

--- a/includes/conditions/class-wdc-user-condition.php
+++ b/includes/conditions/class-wdc-user-condition.php
@@ -10,7 +10,7 @@ class WDC_User_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'user', __( 'User', 'wdc' ), array
+		parent::__construct( 'user', __( 'User', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'user',

--- a/includes/conditions/class-wdc-user_logged_in-condition.php
+++ b/includes/conditions/class-wdc-user_logged_in-condition.php
@@ -10,7 +10,7 @@ class WDC_User_Logged_In_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'user_logged_in', __( 'User Logged In', 'wdc' ), array
+		parent::__construct( 'user_logged_in', __( 'User Logged In', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'user',
@@ -29,7 +29,7 @@ class WDC_User_Logged_In_Condition extends WDC_Condition
 	{
 		$choices = array
 		(
-			'1' => __( 'Yes', 'wdc' ),
+			'1' => __( 'Yes', 'widget-display-conditions' ),
 		);
 
 		return $choices;

--- a/includes/conditions/class-wdc-user_role-condition.php
+++ b/includes/conditions/class-wdc-user_role-condition.php
@@ -10,7 +10,7 @@ class WDC_User_Role_Condition extends WDC_Condition
 	 */
 	public function __construct()
 	{
-		parent::__construct( 'user_role', __( 'User Role', 'wdc' ), array
+		parent::__construct( 'user_role', __( 'User Role', 'widget-display-conditions' ), array
 		(
 			'operators' => array( '==', '!=' ),
 			'category'  => 'user',

--- a/includes/operators/class-wdc-is_equal_to-operator.php
+++ b/includes/operators/class-wdc-is_equal_to-operator.php
@@ -10,7 +10,7 @@ class WDC_Is_Equal_To_Operator extends WDC_Operator
 	 */
 	public function __construct()
 	{
-		parent::__construct( '==', __( 'Is equal to', 'wdc' ), array
+		parent::__construct( '==', __( 'Is equal to', 'widget-display-conditions' ), array
 		(
 			'order' => 10,
 		));

--- a/includes/operators/class-wdc-is_not_equal_to-operator.php
+++ b/includes/operators/class-wdc-is_not_equal_to-operator.php
@@ -10,7 +10,7 @@ class WDC_Is_Not_Equal_To_Operator extends WDC_Operator
 	 */
 	public function __construct()
 	{
-		parent::__construct( '!=', __( 'Is not equal to', 'wdc' ), array
+		parent::__construct( '!=', __( 'Is not equal to', 'widget-display-conditions' ), array
 		(
 			'order' => 20,
 		));

--- a/includes/ui.php
+++ b/includes/ui.php
@@ -44,7 +44,7 @@ final class WDC_UI
 	{		
 		// Output button to open UI
 		$button = sprintf( '<button class="button wdc-open-ui" type="button" data-widget="%s" data-noncename="%s" data-nonce="%s">%s</button>',
-			esc_attr( $widget->id ), esc_attr( WDC_NONCE_NAME ), esc_attr( wp_create_nonce( 'ui' ) ), esc_html__( 'Display conditions', 'wdc' ) );
+			esc_attr( $widget->id ), esc_attr( WDC_NONCE_NAME ), esc_attr( wp_create_nonce( 'ui' ) ), esc_html__( 'Display conditions', 'widget-display-conditions' ) );
 
 		printf( '<p class="wdc-open-ui-wrap">%s<span class="spinner"></span></p>', $button );
 	}
@@ -130,7 +130,7 @@ final class WDC_UI
 		(
 			'messages' => array
 			(
-				'notSaved' => __( 'Confirm unsaved changes.', 'wdc' ),
+				'notSaved' => __( 'Confirm unsaved changes.', 'widget-display-conditions' ),
 			),
 		));
 	}
@@ -148,7 +148,7 @@ final class WDC_UI
 			
 			<div class="wdc-ui">
 
-				<h1><?php _e( 'Widget Display Conditions', 'wdc' ); ?></h1>
+				<h1><?php echo esc_html_x( 'Widget Display Conditions', 'Window Title', 'widget-display-conditions' ); ?></h1>
 
 				<form method="post">
 				
@@ -158,20 +158,20 @@ final class WDC_UI
 					<input type="hidden" name="widget" value="{{ data.widget }}">
 
 					<div class="notice notice-info wdc-hide-if-conditions">
-						<p><?php esc_html_e( __( 'No conditions set.', 'wdc' ) ); ?></p>
+						<p><?php esc_html_e( 'No conditions set.', 'widget-display-conditions' ); ?></p>
 					</div>
 					
-					<h4 class="wdc-show-if-conditions"><?php _e( 'Show widget if', 'wdc' ); ?></h4>
+					<h4 class="wdc-show-if-conditions"><?php esc_html_e( 'Show widget if', 'widget-display-conditions' ); ?></h4>
 
 					<div class="wdc-condition-groups"></div>
 
 					<p>
-						<button class="button wdc-add-condition-group" type="button"><?php esc_html_e( 'Add group', 'wdc' ); ?></button>
+						<button class="button wdc-add-condition-group" type="button"><?php esc_html_e( 'Add group', 'widget-display-conditions' ); ?></button>
 					</p>
 
 					<p class="submit alignright">
 						<span class="spinner"></span>
-						<button class="button button-primary" type="submit" data-saved="<?php esc_attr_e( 'Saved', 'wdc' ); ?>"><?php esc_html_e( 'Save', 'wdc' ); ?></button>
+						<button class="button button-primary" type="submit" data-saved="<?php esc_attr_e( 'Saved', 'widget-display-conditions' ); ?>"><?php esc_html_e( 'Save', 'widget-display-conditions' ); ?></button>
 					</p>
 
 				</form>
@@ -186,7 +186,7 @@ final class WDC_UI
 
 				<table class="wdc-conditions"></table>
 
-				<h4><?php _e( 'or', 'wdc' ); ?></h4>
+				<h4><?php esc_html_e( 'or', 'widget-display-conditions' ); ?></h4>
 
 			</div>
 			
@@ -211,12 +211,12 @@ final class WDC_UI
 				</td>
 
 				<td>
-					<button class="button wdc-add-condition" type="button"><?php esc_html_e( 'and', 'wdc' ); ?></button>
+					<button class="button wdc-add-condition" type="button"><?php esc_html_e( 'and', 'widget-display-conditions' ); ?></button>
 				</td>
 
 				<td>
 					<button class="button-link dashicons-before dashicons-trash wdc-remove-condition" type="button">
-						<span class="screen-reader-text"><?php esc_html_e( 'remove', 'wdc' ); ?></span> 
+						<span class="screen-reader-text"><?php esc_html_e( 'remove', 'widget-display-conditions' ); ?></span> 
 					</button>
 				</td>
 

--- a/includes/updater.php
+++ b/includes/updater.php
@@ -119,7 +119,7 @@ final class WDC_Updater
 
 	public function add_page()
 	{
-		$this->page = add_submenu_page( null, __( 'Widget Display Conditions Updater', 'wdc' ), __( 'Updater', 'wdc' ), 'update_plugins', 'wdc-updater', array( &$this, 'render_page' ) );
+		$this->page = add_submenu_page( null, __( 'Widget Display Conditions Updater', 'widget-display-conditions' ), __( 'Updater', 'widget-display-conditions' ), 'update_plugins', 'wdc-updater', array( &$this, 'render_page' ) );
 	}
 
 	public function render_page()
@@ -130,7 +130,7 @@ final class WDC_Updater
 
 		<div class="wrap">
 
-			<h1><?php esc_html_e( 'Widget Display Conditions Updater', 'wdc' ); ?></h1>
+			<h1><?php esc_html_e( 'Widget Display Conditions Updater', 'widget-display-conditions' ); ?></h1>
 
 			<?php if ( $tasks ) : ?>
 			
@@ -138,15 +138,15 @@ final class WDC_Updater
 					
 				<?php wp_nonce_field( 'update', WDC_NONCE_NAME ); ?>
 
-				<p><strong><?php esc_html_e( 'Database update is required.', 'wdc' ); ?></strong></p>
-				<p><?php esc_html_e( 'Make sure to create a backup before updating.', 'wdc' ); ?></p>
+				<p><strong><?php esc_html_e( 'Database update is required.', 'widget-display-conditions' ); ?></strong></p>
+				<p><?php esc_html_e( 'Make sure to create a backup before updating.', 'widget-display-conditions' ); ?></p>
 
-				<?php submit_button( __( 'Update', 'wdc' ) ); ?>
+				<?php submit_button( __( 'Update', 'widget-display-conditions' ) ); ?>
 
 			</form>
 
 			<?php else : ?>
-			<p><?php esc_html_e( 'Nothing to update.', 'wdc' ); ?></p>
+			<p><?php esc_html_e( 'Nothing to update.', 'widget-display-conditions' ); ?></p>
 			<?php endif; ?>
 
 		</div>
@@ -174,9 +174,9 @@ final class WDC_Updater
 
 		$message = sprintf( '<strong>%s</strong> %s <a href="%s">%s</a>', 
 			esc_html__( $plugin['Name'] ), 
-			esc_html__( 'Database update is required.', 'wdc' ),
+			esc_html__( 'Database update is required.', 'widget-display-conditions' ),
 			admin_url( '?page=wdc-updater' ),
-			esc_html__( 'Go to update page', 'wdc' ) );
+			esc_html__( 'Go to update page', 'widget-display-conditions' ) );
 
 		printf( '<div class="notice notice-warning"><p>%s</p></div>', $message );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: MaartenM
 Tags: widget, display, conditions, rules, sidebar, custom, admin, interface, visibility
 Requires at least: 4.0.0
-Tested up to: 5.2
-Stable tag: 0.2.6
+Tested up to: 5.7.1
+Stable tag: 0.2.8
 Requires PHP: 5.6.27
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -49,6 +49,14 @@ You can use built-in conditions or create some of your own.
 2. Widget Settings with available options
 
 == Changelog ==
+
+= 0.2.8 =
+Release date: April 22nd, 2021
+* Tested in WordPress 5.7.1
+
+= 0.2.7 =
+Release date: June 28th, 2020
+* Tested in WordPress 5.4
 
 = 0.2.6 =
 Release date: May 30th, 2019

--- a/widget-display-conditions.php
+++ b/widget-display-conditions.php
@@ -3,18 +3,18 @@
 Plugin Name:  Widget Display Conditions
 Plugin URI:   https://wordpress.org/plugins/widget-display-conditions/
 Description:  Control on which page you want a particular widget to be displayed.
-Version:      0.2.6
+Version:      0.2.8
 Author:       Maarten Menten
 Author URI:   https://profiles.wordpress.org/maartenm/
 License:      GPL2
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain:  wdc
+Text Domain:  widget-display-conditions
 Domain Path:  /languages
 */
 
 defined( 'WDC_PLUGIN_FILE' )     or define( 'WDC_PLUGIN_FILE', __FILE__ );
 defined( 'WDC_ABSPATH' )         or define( 'WDC_ABSPATH', dirname( WDC_PLUGIN_FILE ) . '/' );
-defined( 'WDC_VERSION' )         or define( 'WDC_VERSION', '0.2.6' );
+defined( 'WDC_VERSION' )         or define( 'WDC_VERSION', '0.2.8' );
 defined( 'WDC_NONCE_NAME' )      or define( 'WDC_NONCE_NAME', 'wdc_nonce' );
 defined( 'WDC_MAX_FIELD_ITEMS' ) or define( 'WDC_MAX_FIELD_ITEMS', 9999 );
 
@@ -44,11 +44,11 @@ function wdc_init()
 	include_once WDC_ABSPATH . 'includes/operators/class-wdc-is_not_equal_to-operator.php';
 
 	// Add condition categories
-	wdc_add_condition_category( 'post'      , __( 'Post', 'wdc' )   , 'order=100' );
-	wdc_add_condition_category( 'page'      , __( 'Page', 'wdc' )   , 'order=200' );
-	wdc_add_condition_category( 'attachment', __( 'Media', 'wdc' )  , 'order=300' );
-	wdc_add_condition_category( 'archive'   , __( 'Archive', 'wdc' ), 'order=400' );
-	wdc_add_condition_category( 'user'      , __( 'User', 'wdc' )   , 'order=500' );
+	wdc_add_condition_category( 'post'      , __( 'Post', 'widget-display-conditions' )   , 'order=100' );
+	wdc_add_condition_category( 'page'      , __( 'Page', 'widget-display-conditions' )   , 'order=200' );
+	wdc_add_condition_category( 'attachment', __( 'Media', 'widget-display-conditions' )  , 'order=300' );
+	wdc_add_condition_category( 'archive'   , __( 'Archive', 'widget-display-conditions' ), 'order=400' );
+	wdc_add_condition_category( 'user'      , __( 'User', 'widget-display-conditions' )   , 'order=500' );
 
 	// Add conditions
 	include_once WDC_ABSPATH . 'includes/conditions/class-wdc-post-condition.php';


### PR DESCRIPTION
- This plugin's slug is `widget-display-conditions`, but the current Text Domain is `widget-display-conditions`. Change the current Text Domain so it is equal to this plugin's slug, and modify the text domain in all your source files. This change is **needed**. Please refer to [this official article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains).
-  **"Requires at least"** (4.0.0) is below 4.6 so a `load_plugin_textdomain` is **needed**, please refer to [this official article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain). **Please add this function by your hand.**